### PR TITLE
Normalize orchestrator task mapping and detail chaining

### DIFF
--- a/Scrapers/inm24_det.py
+++ b/Scrapers/inm24_det.py
@@ -326,11 +326,19 @@ def resolve_url_list_file():
     out = os.environ.get('SCRAPER_OUTPUT_FILE')
     if out:
         parent = os.path.dirname(out)
+        website_code = os.environ.get('SCRAPER_WEBSITE_CODE')
         website = os.environ.get('SCRAPER_WEBSITE', 'Inm24')
-        pattern_prefix = f"{website}URL_"
-        for f in os.listdir(parent):
-            if f.startswith(pattern_prefix) and f.endswith('.csv'):
-                return os.path.join(parent, f)
+        prefixes = []
+        if website_code:
+            prefixes.append(f"{website_code}URL_")
+        if website and website != website_code:
+            prefixes.append(f"{website}URL_")
+        if not prefixes:
+            prefixes.append("Inm24URL_")
+        for prefix in prefixes:
+            for f in os.listdir(parent):
+                if f.startswith(prefix) and f.endswith('.csv'):
+                    return os.path.join(parent, f)
     return None
 
 def main():

--- a/Scrapers/lam_det.py
+++ b/Scrapers/lam_det.py
@@ -124,11 +124,19 @@ def resolve_url_list_file():
     out = os.environ.get('SCRAPER_OUTPUT_FILE')
     if out:
         parent = os.path.dirname(out)
+        website_code = os.environ.get('SCRAPER_WEBSITE_CODE')
         website = os.environ.get('SCRAPER_WEBSITE', 'Lam')
-        pattern_prefix = f"{website}URL_"
-        for f in os.listdir(parent):
-            if f.startswith(pattern_prefix) and f.endswith('.csv'):
-                return os.path.join(parent, f)
+        prefixes = []
+        if website_code:
+            prefixes.append(f"{website_code}URL_")
+        if website and website != website_code:
+            prefixes.append(f"{website}URL_")
+        if not prefixes:
+            prefixes.append("LamURL_")
+        for prefix in prefixes:
+            for f in os.listdir(parent):
+                if f.startswith(prefix) and f.endswith('.csv'):
+                    return os.path.join(parent, f)
     return None
 
 def main():

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,7 @@ data:
 # Configuración de scrapers
 scrapers:
   path: "Scrapers"  # Relativo al directorio del proyecto
-  python_executable: "/home/esdata/Documents/GitHub/Esdata_710/.venv/bin/python3"  # Usar entorno virtual con python3
+  python_executable: "python3"  # Ejecutar con el intérprete disponible en el entorno actual
   timeout_minutes: 30
   memory_limit_mb: 512
 
@@ -29,8 +29,8 @@ execution:
   rate_limit_delay_seconds: 2  # Más rápido en Linux
   max_retry_attempts: 3
   enable_auto_recovery: true
-  single_url_task_per_scraper: true  # Limitar a 1 URL base por scraper; el scraper pagina internamente
-  include_scrapers: ["inm24", "lam", "cyt", "mit"]
+  single_url_task_per_scraper: false  # Procesar todas las filas del CSV en orden
+  include_scrapers: ["inm24", "lam", "cyt", "mit", "prop", "tro"]
   
 # Configuración de monitoreo
 monitoring:
@@ -162,6 +162,61 @@ security:
   rotate_user_agents: true
   use_proxy_rotation: false
   max_requests_per_minute: 30  # Más agresivo en Linux
+
+# Alias y normalización de variables provenientes de los CSV de URLs
+aliases:
+  websites:
+    inmuebles24: Inm24
+    inmuebles_24: Inm24
+    inmuebles-24: Inm24
+    casasyterrenos: CyT
+    casas_y_terrenos: CyT
+    casas-y-terrenos: CyT
+    lamudi: Lam
+    lamudi.com.mx: Lam
+    mitula: Mit
+    mitula.com.mx: Mit
+    propiedades.com: Prop
+    propiedades: Prop
+    trovit: Tro
+    trovit.com.mx: Tro
+  cities:
+    guadalajara: Gdl
+    zapopan: Zap
+    tlajomulco: Tlaj
+    tlaquepaque: Tlaq
+    tonala: Ton
+    el_salto: Salt
+    salto: Salt
+    ixtlahuacan_de_los_membrillos: IMem
+    ixtlahuacan: IMem
+    juanacatlan: Jnctl
+    juanacatlán: Jnctl
+  operations:
+    renta: Ren
+    rentar: Ren
+    rent: Ren
+    alquiler: Ren
+    arrendar: Ren
+    venta: Ven
+    vender: Ven
+    ven: Ven
+    "venta_departamentos": Ven-d
+    "venta-departamentos": Ven-d
+  products:
+    casas: Cas
+    casa: Cas
+    departamentos: Dep
+    departamento: Dep
+    oficinas: Ofc
+    oficina: Ofc
+    comercial: Com
+    comerciales: Com
+    locales: Com
+    edificios: Edif
+    edificio: Edif
+    bodegas: Bod
+    bodegas_comerciales: BodCom
 
 # Configuración de almacenamiento SQL heterogéneo
 data_storage:

--- a/scraper_adapter.py
+++ b/scraper_adapter.py
@@ -61,9 +61,13 @@ class ScraperAdapter:
             os.environ['SCRAPER_OUTPUT_FILE'] = str(abs_output_file)
             os.environ['SCRAPER_BASE_DIR'] = str(self.base_dir)
             os.environ['SCRAPER_WEBSITE'] = str(kwargs.get('website', ''))
+            os.environ['SCRAPER_WEBSITE_CODE'] = str(kwargs.get('website_code', kwargs.get('website', '')))
             os.environ['SCRAPER_CITY'] = str(kwargs.get('city', ''))
+            os.environ['SCRAPER_CITY_CODE'] = str(kwargs.get('city_code', kwargs.get('city', '')))
             os.environ['SCRAPER_OPERATION'] = str(kwargs.get('operation', ''))
+            os.environ['SCRAPER_OPERATION_CODE'] = str(kwargs.get('operation_code', kwargs.get('operation', '')))
             os.environ['SCRAPER_PRODUCT'] = str(kwargs.get('product', ''))
+            os.environ['SCRAPER_PRODUCT_CODE'] = str(kwargs.get('product_code', kwargs.get('product', '')))
             os.environ['SCRAPER_BATCH_ID'] = str(kwargs.get('batch_id', ''))
             os.environ['SCRAPER_INPUT_URL'] = url or ''
             # Limite de paginas (inyectado por orquestador segun sitio/config)
@@ -145,10 +149,23 @@ class ScraperAdapter:
             
             # Buscar el archivo de URLs del scraper principal
             base_scraper = scraper_name.replace('_det', '')
-            url_pattern = f"{base_scraper.upper()}URL_*.csv"
-            
-            url_files = list(output_file.parent.glob(url_pattern))
-            
+            patterns = []
+            website_code = kwargs.get('website_code') or os.environ.get('SCRAPER_WEBSITE_CODE')
+            website_raw = kwargs.get('website') or os.environ.get('SCRAPER_WEBSITE')
+            if website_code:
+                patterns.append(f"{website_code}URL_*.csv")
+            if website_raw and website_raw != website_code:
+                patterns.append(f"{website_raw}URL_*.csv")
+            patterns.append(f"{base_scraper.upper()}URL_*.csv")
+            patterns.append(f"{base_scraper}URL_*.csv")
+
+            url_files = []
+            for pattern in patterns:
+                matches = list(output_file.parent.glob(pattern))
+                if matches:
+                    url_files = matches
+                    break
+
             if not url_files:
                 logger.warning(f"No se encontró archivo de URLs para {scraper_name}")
                 # Crear placeholder


### PR DESCRIPTION
## Summary
- normalize scraper tasks with canonical website, city, operation and product codes so CSV aliases, directory names and detail chaining line up with the YAML configuration
- update the scraper adapter plus inm24_det/lam_det to honor the canonical codes when locating URL bridge files for detail runs
- extend the configuration with execution tweaks and an alias catalogue for all CSV dimensions

## Testing
- python -m compileall orchestrator.py scraper_adapter.py Scrapers/inm24_det.py Scrapers/lam_det.py

------
https://chatgpt.com/codex/tasks/task_e_68cb1f70fd288331962d9e58f588b3b6