### PR TITLE
Normalize orchestrator and scrapers to use abbreviations

### DIFF
--- a/Lista de Variables/Lista de Variables Orquestacion.csv
+++ b/Lista de Variables/Lista de Variables Orquestacion.csv
@@ -1,49 +1,35 @@
-﻿1. LISTA DE VARIABLES PARA LA ORQUESTACION DE LOS SCRAPERS,
-,
-1. PaginaWeb,Name
-Inmuebles24,Inm24
-Casas y Terrenos,CyT
-Lamudi,Lam
-Mitula,Mit
-Propiedades,Prop
-Trovit,Tro
-,
-2. Ciudad,Name
-El Salto,Salt
-Guadalajara,Gdl
-Ixtlahuacan de los Membrillos,IMem
-Juanacatlan,Jnctl
-Tlajomulco de Zuñiga,Tlaj
-San Pedro Tlaquepaque,Tlaq
-Tonala,Ton
-Zapopan,Zap
-Zapotlanejo,Zptl
-,
-3. Operacion,Name
-venta,Ven
-Comprar,Ven
-renta,Ren
-Remate,Ven-r
-Venta de Desarrollo H o V,Ven-d
-,
-4. ProductoPaginaWeb,Name
-Ãtico,Atc
+Variable,Abreviatura
 Bodega,Bod
 Bodegas,Bod
+Bodegas Comerciales,BodC
 Bodegas comerciales,BodC
 Bodegas Industriales,BodI
+Bodegas industriales,BodI
 Bungalow,Bung
 Casa,Cas
+Casa en Condominio,CasC
 Casa en condominio,CasC
 Casa en Fraccionamiento,CasF
+Casa en fraccionamiento,CasF
 Casa uso de suelo,CasU
+casa y terrenos,CyT
 Casas,Cas
+Casas en Condominio,CasC
 Casas en condominio,CasC
+Casas y Terrenos,CyT
+Casas y terrenos,CyT
+Casas_y_Terrenos,CyT
+Casas_y_terrenos,CyT
+casas_y_terrenos,CyT
+Casas_y_terrenos.com,CyT
+compra,Ven
+Comprar,Ven
 Condominio Horizontal,CasH
 Consultorios,Cons
 Cuarto,Cuar
 Cuartos,Cuar
-DÃºplex,Dupl
+CyT,CyT
+Dep,Dep
 Departamento,Dep
 Departamento compartido,DepC
 Departamentos,Dep
@@ -51,21 +37,52 @@ Desarrollo horizontal,DepH
 Desarrollo horizontal/vertical,DepD
 Desarrollo vertical,DepV
 Desarrollos,Desr
+Desván,Desv
 DesvÃ¡n,Desv
 Doctor office,OfcD
+DÃºplex,Dupl
+Dúplex,Dupl
 Edificio,Edf
 Edificios,Edf
+El Salto,Salt
 Estudio,Estd
+GDL,Gdl
+Gdl,Gdl
+Guadalajara,Gdl
+guadalajara,Gdl
 Hacienda,Hac
 Hotel,Hot
 Huerta,Huer
+IMem,IMem
+Inm24,Inm24
 Inmueble productivo urbano,IPU
+Inmuebles24,Inm24
+inmuebles24,Inm24
+Ixtlahuacan de los Membrillos,IMem
+IxtlahuacÁn de los Membrillos,IMem
+Ixtlahuacán de los Membrillos,IMem
+Ixtlahuacán de los membrillos,IMem
+IxtlahuacÃ¡n de los Membrillos,IMem
+IxtlahuacÃ¡n de los membrillos,IMem
+Jnctl,Jnctl
+Juanacatlan,Jnctl
+Juanacatlán,Jnctl
+JuanacatlÃ¡n,Jnctl
+Lam,Lam
+Lamudi,Lam
+lamudi,Lam
 Local Comercial,LocC
+Local en Centro Comercial,LocCP
 Local en centro comercial,LocCP
 Locales,Loc
+locales,Loc
 Locales comerciales,LocC
 Locales en Centros Comerciales,LocCP
 Locales Retail,LocR
+Mit,Mit
+Mitula,Mit
+mitula,Mit
+Nave Industrial,NavI
 Nave industrial,NavI
 Naves Industriales,NavI
 Naves/Bodegas,NavB
@@ -73,9 +90,21 @@ Oficina,Ofc
 Oficinas,Ofc
 Parcela,Parc
 Penthouse,Penth
+Prop,Prop
+Propiedades,Prop
+propiedades,Prop
+Propiedades.com,Prop
+propiedades.com,Prop
 Quinta,Quin
 Rancho,Ranc
 Ranchos,Ranc
+REN,Ren
+Ren,Ren
+Renta,Ren
+renta,Ren
+Rentar,Ren
+Salt,Salt
+San Pedro Tlaquepaque,Tlaq
 Terreno,Terr
 Terreno comercial,TerrC
 Terreno industrial,TerrI
@@ -83,23 +112,36 @@ Terrenos,Terr
 Terrenos Comerciales,TerrC
 Terrenos Habitacionales,TerrH
 Terrenos Industriales,TerrI
+Tlaj,Tlaj
+Tlajomulco,Tlaj
+Tlajomulco de ZuÃ±iga,Tlaj
+Tlajomulco de Zuñiga,Tlaj
+Tlajomulco de ZÃºÃ±iga,Tlaj
+Tlajomulco de Zúñiga,Tlaj
+Tlaq,Tlaq
+Ton,Ton
+Tonala,Ton
+Tonalá,Ton
+TonalÃ¡,Ton
+Tro,Tro
+Trovit,Tro
+trovit,Tro
+VEN,Ven
+Ven,Ven
+Ven-d,Ven-d
+Ven-r,Ven-r
+Venta,Ven
+venta,Ven
+Venta-d,Ven-d
+venta-d,Ven-d
+Venta-r,Ven-r
+venta-r,Ven-r
 Villa,Vill
-,
-5. Meses,Name
-Enero,Ene
-Febrero,Feb
-Marzo,Mar
-Abril,Abr
-Mayo,May
-Junio,Jun
-Julio,Jul
-Agosto,Ago
-Septiembre,Sep
-Octubre,Oct
-Noviembre,Nov
-Diciembre,Dic
-,
-6. Año,Name
-2025,25
-2026,26
-2027,27
+Zap,Zap
+Zapopan,Zap
+zapopan,Zap
+Zapotlanejo,Zptl
+zapotlanejo,Zptl
+Ático,Atc
+Ãtico,Atc
+Ãtico,Atc

--- a/Scrapers/cyt.py
+++ b/Scrapers/cyt.py
@@ -8,9 +8,13 @@ Refactor para integrarse al orquestador moderno:
 Columnas salida (modo URL): source_scraper, website, city, operation, product, listing_url, collected_at
 """
 from __future__ import annotations
+
 import os
+import sys
 import time
 import datetime as dt
+from pathlib import Path
+
 import pandas as pd
 from bs4 import BeautifulSoup
 from selenium import webdriver
@@ -18,6 +22,24 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from abbreviation_utils import get_resolver
+
+ABBREVIATIONS = get_resolver(strict=True)
+
+
+def _clean_value(value) -> str:
+    if pd.isna(value):
+        return ""
+    return str(value).strip()
+
+
+def _env_abbreviation(env_var: str, context: str) -> str:
+    return ABBREVIATIONS.to_abbreviation(os.environ.get(env_var, ''), context=context)
 
 DDIR = 'data/'  # sobrescrito por adapter si aplica legacy
 
@@ -82,10 +104,19 @@ def resolve_base_url(scraper_name: str = 'cyt') -> str | None:
         if os.path.exists(path):
             try:
                 df = pd.read_csv(path)
-                w = os.environ.get('SCRAPER_WEBSITE', '')
-                c = os.environ.get('SCRAPER_CITY', '')
-                o = os.environ.get('SCRAPER_OPERATION', '')
-                p = os.environ.get('SCRAPER_PRODUCT', '')
+                for column in ['PaginaWeb', 'Ciudad', 'Operacion', 'ProductoPaginaWeb']:
+                    if column in df.columns:
+                        df[column] = df[column].apply(
+                            lambda v, col=column: ABBREVIATIONS.to_abbreviation(
+                                _clean_value(v), context=col
+                            )
+                        )
+
+                w = _env_abbreviation('SCRAPER_WEBSITE', 'PaginaWeb')
+                c = _env_abbreviation('SCRAPER_CITY', 'Ciudad')
+                o = _env_abbreviation('SCRAPER_OPERATION', 'Operacion')
+                p = _env_abbreviation('SCRAPER_PRODUCT', 'ProductoPaginaWeb')
+
                 mask = (
                     (df['PaginaWeb'].astype(str) == w) &
                     (df['Ciudad'].astype(str) == c) &
@@ -110,10 +141,10 @@ def url_mode_collect():
         return False
     meta = {
         'source_scraper': 'cyt',
-        'website': os.environ.get('SCRAPER_WEBSITE', 'CyT'),
-        'city': os.environ.get('SCRAPER_CITY', ''),
-        'operation': os.environ.get('SCRAPER_OPERATION', ''),
-        'product': os.environ.get('SCRAPER_PRODUCT', ''),
+        'website': _env_abbreviation('SCRAPER_WEBSITE', 'PaginaWeb') or 'CyT',
+        'city': _env_abbreviation('SCRAPER_CITY', 'Ciudad'),
+        'operation': _env_abbreviation('SCRAPER_OPERATION', 'Operacion'),
+        'product': _env_abbreviation('SCRAPER_PRODUCT', 'ProductoPaginaWeb'),
         'batch_id': os.environ.get('SCRAPER_BATCH_ID', '')
     }
     # Estrategia: detectar parámetro de paginación '?pagina=' o final '?desde=' incremental.

--- a/Scrapers/mit.py
+++ b/Scrapers/mit.py
@@ -6,9 +6,13 @@ Refactor:
   - Modo legacy: scraping reducido acumulativo
 """
 from __future__ import annotations
+
 import os
+import sys
 import time
 import datetime as dt
+from pathlib import Path
+
 import pandas as pd
 from bs4 import BeautifulSoup
 from selenium import webdriver
@@ -16,6 +20,24 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from abbreviation_utils import get_resolver
+
+ABBREVIATIONS = get_resolver(strict=True)
+
+
+def _clean_value(value) -> str:
+    if pd.isna(value):
+        return ""
+    return str(value).strip()
+
+
+def _env_abbreviation(env_var: str, context: str) -> str:
+    return ABBREVIATIONS.to_abbreviation(os.environ.get(env_var, ''), context=context)
 
 DDIR = 'data/'
 
@@ -32,10 +54,19 @@ def resolve_base_url(scraper_name: str = 'mit') -> str | None:
         if os.path.exists(path):
             try:
                 df = pd.read_csv(path)
-                w = os.environ.get('SCRAPER_WEBSITE', '')
-                c = os.environ.get('SCRAPER_CITY', '')
-                o = os.environ.get('SCRAPER_OPERATION', '')
-                p = os.environ.get('SCRAPER_PRODUCT', '')
+                for column in ['PaginaWeb', 'Ciudad', 'Operacion', 'ProductoPaginaWeb']:
+                    if column in df.columns:
+                        df[column] = df[column].apply(
+                            lambda v, col=column: ABBREVIATIONS.to_abbreviation(
+                                _clean_value(v), context=col
+                            )
+                        )
+
+                w = _env_abbreviation('SCRAPER_WEBSITE', 'PaginaWeb')
+                c = _env_abbreviation('SCRAPER_CITY', 'Ciudad')
+                o = _env_abbreviation('SCRAPER_OPERATION', 'Operacion')
+                p = _env_abbreviation('SCRAPER_PRODUCT', 'ProductoPaginaWeb')
+
                 mask = (
                     (df['PaginaWeb'].astype(str) == w) &
                     (df['Ciudad'].astype(str) == c) &
@@ -125,10 +156,10 @@ def url_mode_collect():
         return False
     meta = {
         'source_scraper': 'mit',
-        'website': os.environ.get('SCRAPER_WEBSITE', 'Mit'),
-        'city': os.environ.get('SCRAPER_CITY', ''),
-        'operation': os.environ.get('SCRAPER_OPERATION', ''),
-        'product': os.environ.get('SCRAPER_PRODUCT', ''),
+        'website': _env_abbreviation('SCRAPER_WEBSITE', 'PaginaWeb') or 'Mit',
+        'city': _env_abbreviation('SCRAPER_CITY', 'Ciudad'),
+        'operation': _env_abbreviation('SCRAPER_OPERATION', 'Operacion'),
+        'product': _env_abbreviation('SCRAPER_PRODUCT', 'ProductoPaginaWeb'),
         'batch_id': os.environ.get('SCRAPER_BATCH_ID', '')
     }
     try:

--- a/Scrapers/prop.py
+++ b/Scrapers/prop.py
@@ -6,13 +6,35 @@ Refactor:
 Columnas estándar: source_scraper, website, city, operation, product, listing_url, collected_at
 """
 from __future__ import annotations
+
 import os
 import re
+import sys
 import time
 import datetime as dt
+from pathlib import Path
+
 import pandas as pd
 import requests
 from bs4 import BeautifulSoup
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from abbreviation_utils import get_resolver
+
+ABBREVIATIONS = get_resolver(strict=True)
+
+
+def _clean_value(value) -> str:
+    if pd.isna(value):
+        return ""
+    return str(value).strip()
+
+
+def _env_abbreviation(env_var: str, context: str) -> str:
+    return ABBREVIATIONS.to_abbreviation(os.environ.get(env_var, ''), context=context)
 
 DDIR = 'data/'
 USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
@@ -31,10 +53,19 @@ def resolve_base_url(scraper_name: str = 'prop') -> str | None:
         if os.path.exists(path):
             try:
                 df = pd.read_csv(path)
-                w = os.environ.get('SCRAPER_WEBSITE', '')
-                c = os.environ.get('SCRAPER_CITY', '')
-                o = os.environ.get('SCRAPER_OPERATION', '')
-                p = os.environ.get('SCRAPER_PRODUCT', '')
+                for column in ['PaginaWeb', 'Ciudad', 'Operacion', 'ProductoPaginaWeb']:
+                    if column in df.columns:
+                        df[column] = df[column].apply(
+                            lambda v, col=column: ABBREVIATIONS.to_abbreviation(
+                                _clean_value(v), context=col
+                            )
+                        )
+
+                w = _env_abbreviation('SCRAPER_WEBSITE', 'PaginaWeb')
+                c = _env_abbreviation('SCRAPER_CITY', 'Ciudad')
+                o = _env_abbreviation('SCRAPER_OPERATION', 'Operacion')
+                p = _env_abbreviation('SCRAPER_PRODUCT', 'ProductoPaginaWeb')
+
                 mask = (
                     (df['PaginaWeb'].astype(str) == w) &
                     (df['Ciudad'].astype(str) == c) &
@@ -100,10 +131,10 @@ def url_mode_collect():
         return False
     meta = {
         'source_scraper': 'prop',
-        'website': os.environ.get('SCRAPER_WEBSITE', 'Prop'),
-        'city': os.environ.get('SCRAPER_CITY', ''),
-        'operation': os.environ.get('SCRAPER_OPERATION', ''),
-        'product': os.environ.get('SCRAPER_PRODUCT', ''),
+        'website': _env_abbreviation('SCRAPER_WEBSITE', 'PaginaWeb') or 'Prop',
+        'city': _env_abbreviation('SCRAPER_CITY', 'Ciudad'),
+        'operation': _env_abbreviation('SCRAPER_OPERATION', 'Operacion'),
+        'product': _env_abbreviation('SCRAPER_PRODUCT', 'ProductoPaginaWeb'),
         'batch_id': os.environ.get('SCRAPER_BATCH_ID', '')
     }
     try:

--- a/abbreviation_utils.py
+++ b/abbreviation_utils.py
@@ -19,8 +19,6 @@ DEFAULT_CSV_PATH = (
 
 def _normalize_key(value: str) -> str:
     """Return a lowercase key suitable for dictionary lookups."""
-    if value is None:
-        return ""
     text = str(value).strip()
     if not text:
         return ""

--- a/abbreviation_utils.py
+++ b/abbreviation_utils.py
@@ -51,7 +51,7 @@ class AbbreviationResolver:
             raise ValueError(f"El archivo de abreviaturas está vacío: {path}")
 
         header = rows[0]
-        if len(header) < 2 or header[0].strip().lower() not in {"variable", "valor"}:
+        if len(header) < 2 or header[0].strip().lower() not in {"variable", "valor", "abreviatura"}:
             # El archivo no tiene encabezado estándar; procesar todas las filas
             data_rows = rows
         else:

--- a/abbreviation_utils.py
+++ b/abbreviation_utils.py
@@ -1,0 +1,112 @@
+"""Utility helpers to normalize and map descriptive values to abbreviations."""
+from __future__ import annotations
+
+import csv
+import logging
+import unicodedata
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CSV_PATH = (
+    Path(__file__).resolve().parent
+    / "Lista de Variables"
+    / "Lista de Variables Orquestacion.csv"
+)
+
+
+def _normalize_key(value: str) -> str:
+    """Return a lowercase key suitable for dictionary lookups."""
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    return unicodedata.normalize("NFKC", text).lower()
+
+
+class AbbreviationResolver:
+    """Translate descriptive values into their configured abbreviations."""
+
+    def __init__(self, csv_path: Optional[Path] = None, *, strict: bool = False) -> None:
+        self.csv_path = Path(csv_path) if csv_path else DEFAULT_CSV_PATH
+        self.strict = strict
+        self._mapping, self._abbr_lookup = self._load_mapping(self.csv_path)
+        self._reported_missing: set[str] = set()
+
+    @staticmethod
+    @lru_cache(maxsize=4)
+    def _load_mapping(path: Path) -> tuple[Dict[str, str], Dict[str, str]]:
+        if not path.exists():
+            raise FileNotFoundError(f"No se encontró el archivo de abreviaturas: {path}")
+
+        mapping: Dict[str, str] = {}
+        abbr_lookup: Dict[str, str] = {}
+
+        with path.open(newline="", encoding="utf-8") as csvfile:
+            reader = csv.reader(csvfile)
+            rows = list(reader)
+
+        if not rows:
+            raise ValueError(f"El archivo de abreviaturas está vacío: {path}")
+
+        header = rows[0]
+        if len(header) < 2 or header[0].strip().lower() not in {"variable", "valor"}:
+            # El archivo no tiene encabezado estándar; procesar todas las filas
+            data_rows = rows
+        else:
+            data_rows = rows[1:]
+
+        for row in data_rows:
+            if len(row) < 2:
+                continue
+            raw_value, raw_abbr = row[0].strip(), row[1].strip()
+            if not raw_value or not raw_abbr:
+                continue
+            key = _normalize_key(raw_value)
+            mapping[key] = raw_abbr
+            abbr_lookup[_normalize_key(raw_abbr)] = raw_abbr
+
+        if not mapping:
+            raise ValueError(
+                "No se pudieron cargar abreviaturas desde el archivo proporcionado."
+            )
+
+        return mapping, abbr_lookup
+
+    def to_abbreviation(self, value: Optional[str], *, context: str = "") -> str:
+        """Return the abbreviation for *value*."""
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if not text:
+            return ""
+
+        key = _normalize_key(text)
+        if key in self._mapping:
+            return self._mapping[key]
+        if key in self._abbr_lookup:
+            return self._abbr_lookup[key]
+
+        if self.strict:
+            raise KeyError(f"No se encontró abreviatura para '{value}' ({context})")
+
+        if key not in self._reported_missing:
+            LOGGER.warning("No se encontró abreviatura para '%s' (%s)", text, context)
+            self._reported_missing.add(key)
+
+        return text
+
+    def ensure_all(self, values: Iterable[str], *, context: str = "") -> Dict[str, str]:
+        """Resolve a collection of values and return a mapping original->abbreviation."""
+        result: Dict[str, str] = {}
+        for value in values:
+            result[value] = self.to_abbreviation(value, context=context)
+        return result
+
+
+def get_resolver(csv_path: Optional[Path] = None, *, strict: bool = False) -> AbbreviationResolver:
+    """Convenience factory that reuses cached mappings."""
+    return AbbreviationResolver(csv_path=csv_path, strict=strict)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,7 @@ data:
 # Configuración de scrapers
 scrapers:
   path: "Scrapers"  # Relativo al directorio del proyecto
-  python_executable: "/home/esdata/Documents/GitHub/Esdata_710/.venv/bin/python3"  # Usar entorno virtual con python3
+  python_executable: "python3"  # Ejecutable genérico para entornos locales
   timeout_minutes: 30
   memory_limit_mb: 512
 
@@ -29,7 +29,7 @@ execution:
   rate_limit_delay_seconds: 2  # Más rápido en Linux
   max_retry_attempts: 3
   enable_auto_recovery: true
-  single_url_task_per_scraper: true  # Limitar a 1 URL base por scraper; el scraper pagina internamente
+  single_url_task_per_scraper: false  # Permitir que la orquestación recorra todas las filas del CSV
   include_scrapers: ["inm24", "lam", "cyt", "mit"]
   
 # Configuración de monitoreo

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -348,7 +348,7 @@ class LinuxScrapingOrchestrator:
                     self._clean_csv_value(row.get('ProductoPaginaWeb', '')),
                     context='ProductoPaginaWeb'
                 )
-                expected_site = self.scraper_expected_sites.get(scraper_name.lower())
+                expected_site = self.abbreviation_resolver.to_abbreviation(scraper_name, context='PaginaWeb')
                 if expected_site and website != expected_site:
                     notify_key = (scraper_name, website)
                     if notify_key not in self._website_override_notified:

--- a/scraper_adapter.py
+++ b/scraper_adapter.py
@@ -37,7 +37,11 @@ class ScraperAdapter:
         try:
             # Cambiar al directorio de scrapers
             os.chdir(self.scrapers_dir)
-            
+
+            # Asegurar que el repositorio raíz esté disponible para imports compartidos
+            if str(self.base_dir) not in sys.path:
+                sys.path.insert(0, str(self.base_dir))
+
             # Importar el módulo del scraper
             spec = importlib.util.spec_from_file_location(scraper_name, scraper_path)
             if spec is None:
@@ -145,10 +149,14 @@ class ScraperAdapter:
             
             # Buscar el archivo de URLs del scraper principal
             base_scraper = scraper_name.replace('_det', '')
-            url_pattern = f"{base_scraper.upper()}URL_*.csv"
-            
+            website_code = kwargs.get('website') or base_scraper
+            url_pattern = f"{website_code}URL_*.csv"
+
             url_files = list(output_file.parent.glob(url_pattern))
-            
+            if not url_files:
+                url_pattern_upper = f"{website_code.upper()}URL_*.csv"
+                url_files = list(output_file.parent.glob(url_pattern_upper))
+
             if not url_files:
                 logger.warning(f"No se encontró archivo de URLs para {scraper_name}")
                 # Crear placeholder


### PR DESCRIPTION
## Summary
- add an abbreviation resolver and enforce code-based website keys when loading tasks in the orchestrator
- update configuration and the shared variables CSV so every value has an explicit abbreviation entry
- refactor the primary scrapers and adapter to consume the shared resolver and emit abbreviated metadata consistently

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cb23cae43883319814838793ee5b69